### PR TITLE
Uses a mixin to generate all widths

### DIFF
--- a/_trumps.widths.scss
+++ b/_trumps.widths.scss
@@ -66,7 +66,7 @@ $inuit-namespace: null !default;
         }
       }
 
-      $selector: '[class*="#{$inuit-namespace}#{$part-selector}#{$separator-selector}#{$whole-selector}"]';
+      $selector: '[class~="#{$inuit-namespace}#{$part-selector}#{$separator-selector}#{$whole-selector}"]';
 
       // First uses of a specific width.
       @if map-get($inuit-width-map, #{$inuit-namespace} + $width) == null {

--- a/_trumps.widths.scss
+++ b/_trumps.widths.scss
@@ -9,184 +9,83 @@
  * `$inuit-use-fractions` variable defined below.
  */
 
-$inuit-use-fractions:   true !default;
+$inuit-use-fractions: true !default;
+$inuit-widths: 2, 3, 4, 5, 6, 8, 9, 10, 12 !default;
+$inuit-namespace: null !default;
 
-@if $inuit-use-fractions == true {
+@mixin inuit-widths($wholes...) {
+  $inuit-width-map: () !default !global;
+  $parts-map: (
+    1:  One,
+    2:  Two,
+    3:  Three,
+    4:  Four,
+    5:  Five,
+    6:  Six,
+    7:  Seven,
+    8:  Height,
+    9:  Nine,
+    10: Ten,
+    11: Eleven
+  );
+  $wholes-map: (
+    2:  Half,
+    3:  Third,
+    4:  Quarter,
+    5:  Fifths,
+    6:  Sixths,
+    7:  Seventh,
+    8:  Eighths,
+    9:  Ninths,
+    10: Tenths,
+    11: Eleventh,
+    12: Twelfths
+  );
 
-/**
- * Halves.
- */
-[class*="#{$inuit-namespace}1/2"],
-[class*="#{$inuit-namespace}2/4"],
-[class*="#{$inuit-namespace}3/6"],
-[class*="#{$inuit-namespace}4/8"],
-[class*="#{$inuit-namespace}5/10"],
-[class*="#{$inuit-namespace}6/12"]      { width: 50% !important; }
+  @each $whole in $wholes {
+    $part: 1;
 
-/**
- * Thirds.
- */
-[class*="#{$inuit-namespace}1/3"],
-[class*="#{$inuit-namespace}2/6"],
-[class*="#{$inuit-namespace}3/9"],
-[class*="#{$inuit-namespace}4/12"]      { width: 33.3333333% !important; }
-[class*="#{$inuit-namespace}2/3"]
-[class*="#{$inuit-namespace}4/6"],
-[class*="#{$inuit-namespace}6/9"],
-[class*="#{$inuit-namespace}8/12"]      { width: 66.6666666% !important; }
+    /**
+     * #{map-get($wholes-map, $whole) or $whole + th}.
+     */
 
-/**
- * Quarters.
- */
-[class*="#{$inuit-namespace}1/4"],
-[class*="#{$inuit-namespace}2/8"],
-[class*="#{$inuit-namespace}3/12"]      { width: 25% !important; }
-[class*="#{$inuit-namespace}3/4"],
-[class*="#{$inuit-namespace}6/8"],
-[class*="#{$inuit-namespace}9/12"]      { width: 75% !important; }
+    @while $part < $whole {
+      $part-selector: #{$part};
+      $separator-selector: "/";
+      $whole-selector: #{$whole};
+      $width: $part / $whole * 100 + "%";
 
-/**
- * Fifths.
- */
-[class*="#{$inuit-namespace}1/5"],
-[class*="#{$inuit-namespace}2/10"]      { width: 20% !important; }
-[class*="#{$inuit-namespace}2/5"],
-[class*="#{$inuit-namespace}4/10"]      { width: 40% !important; }
-[class*="#{$inuit-namespace}3/5"],
-[class*="#{$inuit-namespace}6/10"]      { width: 60% !important; }
-[class*="#{$inuit-namespace}4/5"],
-[class*="#{$inuit-namespace}8/10"]      { width: 80% !important; }
+      // Use spoken-words & check if the corresponding word exists in $wholes-map.
+      @if $inuit-use-fractions == false {
+        @if map-get($wholes-map, $whole) != null and map-get($parts-map, $part) != null {
+          $part-selector: #{to-lower-case(map-get($parts-map, $part))};
+          $separator-selector: "-";
+          $whole-selector: #{to-lower-case(map-get($wholes-map, $whole))};
+        } @else {
+          @warn $whole + " is an undefined spoken-word width in Inuit.css.";
+        }
+      }
 
-/**
- * Sixths.
- */
-[class*="#{$inuit-namespace}1/6"],
-[class*="#{$inuit-namespace}2/12"]      { width: 16.6666666% !important; }
-[class*="#{$inuit-namespace}5/6"],
-[class*="#{$inuit-namespace}10/12"]     { width: 83.3333333% !important; }
+      $selector: '[class*="#{$inuit-namespace}#{$part-selector}#{$separator-selector}#{$whole-selector}"]';
 
-/**
- * Eighths.
- */
-[class*="#{$inuit-namespace}1/8"]       { width: 12.5% !important; }
-[class*="#{$inuit-namespace}3/8"]       { width: 37.5% !important; }
-[class*="#{$inuit-namespace}5/8"]       { width: 62.5% !important; }
-[class*="#{$inuit-namespace}7/8"]       { width: 87.5% !important; }
+      // First uses of a specific width.
+      @if map-get($inuit-width-map, #{$inuit-namespace} + $width) == null {
+        $inuit-width-map: map-merge($inuit-width-map,(#{$inuit-namespace} + $width: $selector)) !global;
+        #{$selector} {
+          width: #{$width} !important;
+        }
+      }
 
-/**
- * Ninths.
- */
-[class*="#{$inuit-namespace}1/9"]       { width: 11.1111111% !important; }
-[class*="#{$inuit-namespace}2/9"]       { width: 22.2222222% !important; }
-[class*="#{$inuit-namespace}4/9"]       { width: 44.4444444% !important; }
-[class*="#{$inuit-namespace}5/9"]       { width: 55.5555555% !important; }
-[class*="#{$inuit-namespace}7/9"]       { width: 77.7777777% !important; }
-[class*="#{$inuit-namespace}8/9"]       { width: 88.8888888% !important; }
+      // Extend a previous selector which has the same width property.
+      @else {
+        #{$selector} {
+          @extend #{map-get($inuit-width-map, #{$inuit-namespace} + $width)};
+        }
+      }
 
-/**
- * Tenths.
- */
-[class*="#{$inuit-namespace}1/10"]      { width: 10% !important; }
-[class*="#{$inuit-namespace}3/10"]      { width: 30% !important; }
-[class*="#{$inuit-namespace}7/10"]      { width: 70% !important; }
-[class*="#{$inuit-namespace}9/10"]      { width: 90% !important; }
-
-/**
- * Twelfths.
- */
-[class*="#{$inuit-namespace}1/12"]      { width:  8.3333333% !important; }
-[class*="#{$inuit-namespace}5/12"]      { width: 41.6666666% !important; }
-[class*="#{$inuit-namespace}7/12"]      { width: 58.3333333% !important; }
-[class*="#{$inuit-namespace}11/12"]     { width: 91.6666666% !important; }
-
+      $part: $part + 1;
+    }
+  }
 }
 
-@else {
-
-/**
- * Halves.
- */
-.#{$inuit-namespace}one-half,
-.#{$inuit-namespace}two-quarters,
-.#{$inuit-namespace}three-sixths,
-.#{$inuit-namespace}four-eighths,
-.#{$inuit-namespace}five-tenths,
-.#{$inuit-namespace}six-twelfths        { width: 50% !important; }
-
-/**
- * Thirds.
- */
-.#{$inuit-namespace}one-third,
-.#{$inuit-namespace}two-sixths,
-.#{$inuit-namespace}three-ninths,
-.#{$inuit-namespace}four-twelfths       { width: 33.3333333% !important; }
-.#{$inuit-namespace}two-thirds
-.#{$inuit-namespace}four-sixths,
-.#{$inuit-namespace}six-ninths,
-.#{$inuit-namespace}eight-twelfths      { width: 66.6666666% !important; }
-
-/**
- * Quarters.
- */
-.#{$inuit-namespace}one-quarter,
-.#{$inuit-namespace}two-eighths,
-.#{$inuit-namespace}three-twelfths      { width: 25% !important; }
-.#{$inuit-namespace}three-quarters,
-.#{$inuit-namespace}six-eighths,
-.#{$inuit-namespace}nine-twelfths       { width: 75% !important; }
-
-/**
- * Fifths.
- */
-.#{$inuit-namespace}one-fifth,
-.#{$inuit-namespace}two-tenths          { width: 20% !important; }
-.#{$inuit-namespace}two-fifths,
-.#{$inuit-namespace}four-tenths         { width: 40% !important; }
-.#{$inuit-namespace}three-fifths,
-.#{$inuit-namespace}six-tenths          { width: 60% !important; }
-.#{$inuit-namespace}four-fifths,
-.#{$inuit-namespace}eight-tenths        { width: 80% !important; }
-
-/**
- * Sixths.
- */
-.#{$inuit-namespace}one-sixth,
-.#{$inuit-namespace}two-twelfths        { width: 16.6666666% !important; }
-.#{$inuit-namespace}five-sixths,
-.#{$inuit-namespace}ten-twelfths        { width: 83.3333333% !important; }
-
-/**
- * Eighths.
- */
-.#{$inuit-namespace}one-eighth          { width: 12.5% !important; }
-.#{$inuit-namespace}three-eighths       { width: 37.5% !important; }
-.#{$inuit-namespace}five-eighths        { width: 62.5% !important; }
-.#{$inuit-namespace}seven-eighths       { width: 87.5% !important; }
-
-/**
- * Ninths.
- */
-.#{$inuit-namespace}one-ninth           { width: 11.1111111% !important; }
-.#{$inuit-namespace}two-ninths          { width: 22.2222222% !important; }
-.#{$inuit-namespace}four-ninths         { width: 44.4444444% !important; }
-.#{$inuit-namespace}five-ninths         { width: 55.5555555% !important; }
-.#{$inuit-namespace}seven-ninths        { width: 77.7777777% !important; }
-.#{$inuit-namespace}eight-ninths        { width: 88.8888888% !important; }
-
-/**
- * Tenths.
- */
-.#{$inuit-namespace}one-tenth           { width: 10% !important; }
-.#{$inuit-namespace}three-tenths        { width: 30% !important; }
-.#{$inuit-namespace}seven-tenths        { width: 70% !important; }
-.#{$inuit-namespace}nine-tenths         { width: 90% !important; }
-
-/**
- * Twelfths.
- */
-.#{$inuit-namespace}one-twelfth         { width:  8.3333333% !important; }
-.#{$inuit-namespace}five-twelfths       { width: 41.6666666% !important; }
-.#{$inuit-namespace}seven-twelfths      { width: 58.3333333% !important; }
-.#{$inuit-namespace}eleven-twelfths     { width: 91.6666666% !important; }
-
-}
+@include inuit-widths($inuit-widths...);

--- a/_trumps.widths.scss
+++ b/_trumps.widths.scss
@@ -32,14 +32,14 @@ $inuit-namespace: null !default;
     2:  Half,
     3:  Third,
     4:  Quarter,
-    5:  Fifths,
-    6:  Sixths,
+    5:  Fifth,
+    6:  Sixth,
     7:  Seventh,
-    8:  Eighths,
-    9:  Ninths,
-    10: Tenths,
+    8:  Eighth,
+    9:  Ninth,
+    10: Tenth,
     11: Eleventh,
-    12: Twelfths
+    12: Twelfth
   );
 
   @each $whole in $wholes {
@@ -61,6 +61,12 @@ $inuit-namespace: null !default;
           $part-selector: #{to-lower-case(map-get($parts-map, $part))};
           $separator-selector: "-";
           $whole-selector: #{to-lower-case(map-get($wholes-map, $whole))};
+
+          // Pluralize the selector
+          @if $part > 1 {
+            $whole-selector: $whole-selector + 's';
+          }
+
         } @else {
           @warn $whole + " is an undefined spoken-word width in Inuit.css.";
         }
@@ -70,7 +76,7 @@ $inuit-namespace: null !default;
 
       // First uses of a specific width.
       @if map-get($inuit-width-map, #{$inuit-namespace} + $width) == null {
-        $inuit-width-map: map-merge($inuit-width-map,(#{$inuit-namespace} + $width: $selector)) !global;
+        $inuit-width-map: map-merge($inuit-width-map, (#{$inuit-namespace} + $width: $selector)) !global;
         #{$selector} {
           width: #{$width} !important;
         }


### PR DESCRIPTION
I played a bit in this file/repo and created a mixin to generate dynamically all widths. This is related to https://github.com/inuitcss/trumps.widths/issues/1.

It uses Sass 3.3 and the new map data type (this new version of Sass will probably be released some time [in January](https://gist.github.com/nex3/8050187)).

`@include widths(2, 3, 4, 5, 6, 8, 9, 10, 12)` can accept any numbers.
So we can easily generate only the widths we need, including after 12. E.g.: `@include inuit-widths(4, 12, 16)`.
It also support spoken-word format up to 12 (after 12 the mixin will warn the user and it will use the fractions instead).

Of course it combine selectors which have the same widths (like the previous implementation).

The arguments in the `inuit-widths` mixin could be stored in a variable defined in the `_settings.defaults`. And I was not sure but if I follow your architecture, this mixin should have a better place in `_tools.mixins.scss`.

<del>Also, I was wondering why you split Inuit.css in a lot of different repos, because I think it will be more difficult for the community to follow this frameworks, and particularly send pull requests across this project (but this is my point of view and you probably have good reasons to do that).</del>


Feel free to accept or not my PR, and correct my bad English :)
