### PR TITLE
Add a missing comma after the `.#{$inuit-namespace}two-thirds` class.

### DIFF
--- a/_trumps.widths.scss
+++ b/_trumps.widths.scss
@@ -120,7 +120,7 @@ $inuit-use-fractions:   true !default;
 .#{$inuit-namespace}two-sixths,
 .#{$inuit-namespace}three-ninths,
 .#{$inuit-namespace}four-twelfths       { width: 33.3333333% !important; }
-.#{$inuit-namespace}two-thirds
+.#{$inuit-namespace}two-thirds,
 .#{$inuit-namespace}four-sixths,
 .#{$inuit-namespace}six-ninths,
 .#{$inuit-namespace}eight-twelfths      { width: 66.6666666% !important; }


### PR DESCRIPTION
Restores a missing separator comma after the `.#{$inuit-namespace}two-thirds` class.
