### PR TITLE
Use ~ attribute selector to avoid partial matches

### DIFF
--- a/_trumps.widths.scss
+++ b/_trumps.widths.scss
@@ -16,88 +16,87 @@ $inuit-use-fractions:   true !default;
 /**
  * Halves.
  */
-[class*="#{$inuit-namespace}1/2"],
-[class*="#{$inuit-namespace}2/4"],
-[class*="#{$inuit-namespace}3/6"],
-[class*="#{$inuit-namespace}4/8"],
-[class*="#{$inuit-namespace}5/10"],
-[class*="#{$inuit-namespace}6/12"]      { width: 50% !important; }
+[class~="#{$inuit-namespace}1/2"],
+[class~="#{$inuit-namespace}2/4"],
+[class~="#{$inuit-namespace}3/6"],
+[class~="#{$inuit-namespace}4/8"],
+[class~="#{$inuit-namespace}5/10"],
+[class~="#{$inuit-namespace}6/12"]      { width: 50% !important; }
 
 /**
  * Thirds.
  */
-[class*="#{$inuit-namespace}1/3"],
-[class*="#{$inuit-namespace}2/6"],
-[class*="#{$inuit-namespace}3/9"],
-[class*="#{$inuit-namespace}4/12"]      { width: 33.3333333% !important; }
-[class*="#{$inuit-namespace}2/3"]
-[class*="#{$inuit-namespace}4/6"],
-[class*="#{$inuit-namespace}6/9"],
-[class*="#{$inuit-namespace}8/12"]      { width: 66.6666666% !important; }
+[class~="#{$inuit-namespace}1/3"],
+[class~="#{$inuit-namespace}2/6"],
+[class~="#{$inuit-namespace}3/9"],
+[class~="#{$inuit-namespace}4/12"]      { width: 33.3333333% !important; }
+[class~="#{$inuit-namespace}2/3"]
+[class~="#{$inuit-namespace}4/6"],
+[class~="#{$inuit-namespace}6/9"],
+[class~="#{$inuit-namespace}8/12"]      { width: 66.6666666% !important; }
 
 /**
  * Quarters.
  */
-[class*="#{$inuit-namespace}1/4"],
-[class*="#{$inuit-namespace}2/8"],
-[class*="#{$inuit-namespace}3/12"]      { width: 25% !important; }
-[class*="#{$inuit-namespace}3/4"],
-[class*="#{$inuit-namespace}6/8"],
-[class*="#{$inuit-namespace}9/12"]      { width: 75% !important; }
+[class~="#{$inuit-namespace}1/4"],
+[class~="#{$inuit-namespace}2/8"],
+[class~="#{$inuit-namespace}3/12"]      { width: 25% !important; }
+[class~="#{$inuit-namespace}3/4"],
+[class~="#{$inuit-namespace}6/8"],
+[class~="#{$inuit-namespace}9/12"]      { width: 75% !important; }
 
 /**
  * Fifths.
  */
-[class*="#{$inuit-namespace}1/5"],
-[class*="#{$inuit-namespace}2/10"]      { width: 20% !important; }
-[class*="#{$inuit-namespace}2/5"],
-[class*="#{$inuit-namespace}4/10"]      { width: 40% !important; }
-[class*="#{$inuit-namespace}3/5"],
-[class*="#{$inuit-namespace}6/10"]      { width: 60% !important; }
-[class*="#{$inuit-namespace}4/5"],
-[class*="#{$inuit-namespace}8/10"]      { width: 80% !important; }
+[class~="#{$inuit-namespace}1/5"],
+[class~="#{$inuit-namespace}2/10"]      { width: 20% !important; }
+[class~="#{$inuit-namespace}2/5"],
+[class~="#{$inuit-namespace}4/10"]      { width: 40% !important; }
+[class~="#{$inuit-namespace}3/5"],
+[class~="#{$inuit-namespace}6/10"]      { width: 60% !important; }
+[class~="#{$inuit-namespace}4/5"],
+[class~="#{$inuit-namespace}8/10"]      { width: 80% !important; }
 
 /**
  * Sixths.
  */
-[class*="#{$inuit-namespace}1/6"],
-[class*="#{$inuit-namespace}2/12"]      { width: 16.6666666% !important; }
-[class*="#{$inuit-namespace}5/6"],
-[class*="#{$inuit-namespace}10/12"]     { width: 83.3333333% !important; }
-
+[class~="#{$inuit-namespace}1/6"],
+[class~="#{$inuit-namespace}2/12"]      { width: 16.6666666% !important; }
+[class~="#{$inuit-namespace}5/6"],
+[class~="#{$inuit-namespace}10/12"]     { width: 83.3333333% !important; }
 /**
  * Eighths.
  */
-[class*="#{$inuit-namespace}1/8"]       { width: 12.5% !important; }
-[class*="#{$inuit-namespace}3/8"]       { width: 37.5% !important; }
-[class*="#{$inuit-namespace}5/8"]       { width: 62.5% !important; }
-[class*="#{$inuit-namespace}7/8"]       { width: 87.5% !important; }
+[class~="#{$inuit-namespace}1/8"]       { width: 12.5% !important; }
+[class~="#{$inuit-namespace}3/8"]       { width: 37.5% !important; }
+[class~="#{$inuit-namespace}5/8"]       { width: 62.5% !important; }
+[class~="#{$inuit-namespace}7/8"]       { width: 87.5% !important; }
 
 /**
  * Ninths.
  */
-[class*="#{$inuit-namespace}1/9"]       { width: 11.1111111% !important; }
-[class*="#{$inuit-namespace}2/9"]       { width: 22.2222222% !important; }
-[class*="#{$inuit-namespace}4/9"]       { width: 44.4444444% !important; }
-[class*="#{$inuit-namespace}5/9"]       { width: 55.5555555% !important; }
-[class*="#{$inuit-namespace}7/9"]       { width: 77.7777777% !important; }
-[class*="#{$inuit-namespace}8/9"]       { width: 88.8888888% !important; }
+[class~="#{$inuit-namespace}1/9"]       { width: 11.1111111% !important; }
+[class~="#{$inuit-namespace}2/9"]       { width: 22.2222222% !important; }
+[class~="#{$inuit-namespace}4/9"]       { width: 44.4444444% !important; }
+[class~="#{$inuit-namespace}5/9"]       { width: 55.5555555% !important; }
+[class~="#{$inuit-namespace}7/9"]       { width: 77.7777777% !important; }
+[class~="#{$inuit-namespace}8/9"]       { width: 88.8888888% !important; }
 
 /**
  * Tenths.
  */
-[class*="#{$inuit-namespace}1/10"]      { width: 10% !important; }
-[class*="#{$inuit-namespace}3/10"]      { width: 30% !important; }
-[class*="#{$inuit-namespace}7/10"]      { width: 70% !important; }
-[class*="#{$inuit-namespace}9/10"]      { width: 90% !important; }
+[class~="#{$inuit-namespace}1/10"]      { width: 10% !important; }
+[class~="#{$inuit-namespace}3/10"]      { width: 30% !important; }
+[class~="#{$inuit-namespace}7/10"]      { width: 70% !important; }
+[class~="#{$inuit-namespace}9/10"]      { width: 90% !important; }
 
 /**
  * Twelfths.
  */
-[class*="#{$inuit-namespace}1/12"]      { width:  8.3333333% !important; }
-[class*="#{$inuit-namespace}5/12"]      { width: 41.6666666% !important; }
-[class*="#{$inuit-namespace}7/12"]      { width: 58.3333333% !important; }
-[class*="#{$inuit-namespace}11/12"]     { width: 91.6666666% !important; }
+[class~="#{$inuit-namespace}1/12"]      { width:  8.3333333% !important; }
+[class~="#{$inuit-namespace}5/12"]      { width: 41.6666666% !important; }
+[class~="#{$inuit-namespace}7/12"]      { width: 58.3333333% !important; }
+[class~="#{$inuit-namespace}11/12"]     { width: 91.6666666% !important; }
 
 }
 


### PR DESCRIPTION
If you plan on using responsive widths in a similar way as in inuit 5, the `*=` attribute selector would match on partial results. For example: `<div class="layout__item 1/4 palm-1/2">` would pick up both `[class*="1/4"]` AND `[class=*"1/2"]` as it's found a match on `1/2` and `1/4`. 

You would start picking up issues in the cascade with a `layout__item` inheriting the wrong width at the wrong breakpoints. Using the above example, it would probably appear as `1/2` at all times.

By using the `~=` selector, it looks for a full match within an elements classes. I've been successfully using this method with my own (inuit inspired) fractional grid, [Matryo](http://quagliero.github.io/matryosass).
